### PR TITLE
Generate sitemap

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -59,6 +59,15 @@ jobs:
           rm -rf allwpilib/docs/development/java allwpilib/docs/development/cpp
           mv allwpilib/docs/development/javadoc allwpilib/docs/development/java
           mv allwpilib/docs/development/doxygen/html allwpilib/docs/development/cpp
+      - name: Get pages url
+        run: echo url=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url') >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install sitemap generator
+        run: npm install -g static-sitemap-cli@^2.2.5
+      - name: Generate sitemaps
+        # Disable robots because we don't need it and it opens every html file
+        run: static-sitemap-cli --base ${{ env.url }} --root . --no-robots --verbose --no-clean
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install sitemap generator
         run: npm install -g static-sitemap-cli@^2.2.5
       - name: Generate sitemap
-        run: static-sitemap-cli --base ${{ env.url }} --root . --ignore "allwpilib/docs/beta/**" "allwpilib/docs/development/**" --verbose --no-clean
+        run: static-sitemap-cli --base ${{ env.url }} --root . --ignore "allwpilib/docs/beta/**" "allwpilib/docs/development/**" --changefreq  "**,monthly" "allwpilib/docs/**,weekly" --verbose --no-clean
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -65,9 +65,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sitemap generator
         run: npm install -g static-sitemap-cli@^2.2.5
-      - name: Generate sitemaps
-        # Disable robots because we don't need it and it opens every html file
-        run: static-sitemap-cli --base ${{ env.url }} --root . --no-robots --verbose --no-clean
+      - name: Generate sitemap
+        run: static-sitemap-cli --base ${{ env.url }} --root . --ignore "allwpilib/docs/beta/**" "allwpilib/docs/development/**" --verbose --no-clean
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /allwpilib/docs/beta/
+Disallow: /allwpilib/docs/development/
+
+Sitemap: https://github.wpilib.org/sitemap.xml


### PR DESCRIPTION
Might help with SEO
~~If we get near 50,000 urls we'll have to split into multiple maps, which is fairly easy. We're at \~23,000 currently.
Robots.txt and `noindex` parsing is disabled because we don't use them and enabling that feature opens every single html file which on my machine causes a "too many files open" error.~~
With dev and beta disabled we're at 7000ish urls and it runs fine

test run here: https://github.com/rzblue/wpilibsuite-pages/actions/runs/10280353644/job/28447505581
sitemap: https://rzblue.github.io/wpilibsuite-pages/sitemap.xml
